### PR TITLE
HardwareTimer: Fix frequency computation when there is no more signal

### DIFF
--- a/examples/Peripherals/HardwareTimer/Frequency_Dutycycle_measurement/Frequency_Dutycycle_measurement.ino
+++ b/examples/Peripherals/HardwareTimer/Frequency_Dutycycle_measurement/Frequency_Dutycycle_measurement.ino
@@ -38,6 +38,13 @@ void TIMINPUT_Capture_Rising_IT_callback(HardwareTimer*)
   LastPeriodCapture = CurrentCapture;
 }
 
+/* In case of timer rollover, frequency is to low to be measured set values to 0
+   To reduce minimum frequency, it is possible to increase prescaler. But this is at a cost of precision. */
+void Rollover_IT_callback(HardwareTimer*)
+{
+  FrequencyMeasured = 0;
+  DutycycleMeasured = 0;
+}
 
 /**
     @brief  Input capture interrupt callback : Compute frequency and dutycycle of input signal
@@ -103,6 +110,7 @@ void setup()
   MyTim->setOverflow(0x10000); // Max Period value to have the largest possible time to detect rising edge and avoid timer rollover
   MyTim->attachInterrupt(channelRising, TIMINPUT_Capture_Rising_IT_callback);
   MyTim->attachInterrupt(channelFalling, TIMINPUT_Capture_Falling_IT_callback);
+  MyTim->attachInterrupt(Rollover_IT_callback);
 
   MyTim->resume();
 

--- a/examples/Peripherals/HardwareTimer/InputCapture/InputCapture.ino
+++ b/examples/Peripherals/HardwareTimer/InputCapture/InputCapture.ino
@@ -27,6 +27,12 @@ void InputCapture_IT_callback(HardwareTimer*)
   LastCapture = CurrentCapture;
 }
 
+/* In case of timer rollover, frequency is to low to be measured set value to 0
+   To reduce minimum frequency, it is possible to increase prescaler. But this is at a cost of precision. */
+void Rollover_IT_callback(HardwareTimer*)
+{
+  FrequencyMeasured = 0;
+}
 
 void setup()
 {
@@ -53,6 +59,7 @@ void setup()
   MyTim->setPrescaleFactor(PrescalerFactor);
   MyTim->setOverflow(0x10000); // Max Period value to have the largest possible time to detect rising edge and avoid timer rollover
   MyTim->attachInterrupt(channel, InputCapture_IT_callback);
+  MyTim->attachInterrupt(Rollover_IT_callback);
   MyTim->resume();
 
   // Compute this scale factor only once


### PR DESCRIPTION
When HardwareTimer is used in input capture mode,
we need to handle the case where timer counter rollover.
Let's set values to 0 in both examples:
* InputCapture
* Frequency_Dutycycle_measurement
Fixes #789