### PR TITLE
Computed frequency = 0, with input signal present

### DIFF
--- a/examples/Peripherals/HardwareTimer/Frequency_Dutycycle_measurement/Frequency_Dutycycle_measurement.ino
+++ b/examples/Peripherals/HardwareTimer/Frequency_Dutycycle_measurement/Frequency_Dutycycle_measurement.ino
@@ -13,6 +13,7 @@
 uint32_t channelRising, channelFalling;
 volatile uint32_t FrequencyMeasured, DutycycleMeasured, LastPeriodCapture = 0, CurrentCapture, HighStateMeasured;
 uint32_t input_freq = 0;
+volatile uint32_t rolloverCompareCount = 0;
 HardwareTimer *MyTim;
 
 /**
@@ -36,14 +37,20 @@ void TIMINPUT_Capture_Rising_IT_callback(HardwareTimer*)
   }
 
   LastPeriodCapture = CurrentCapture;
+  rolloverCompareCount = 0;
 }
 
 /* In case of timer rollover, frequency is to low to be measured set values to 0
    To reduce minimum frequency, it is possible to increase prescaler. But this is at a cost of precision. */
 void Rollover_IT_callback(HardwareTimer*)
 {
-  FrequencyMeasured = 0;
-  DutycycleMeasured = 0;
+  rolloverCompareCount++;
+
+  if (rolloverCompareCount > 1)
+  {
+    FrequencyMeasured = 0;
+    DutycycleMeasured = 0;
+  }
 }
 
 /**

--- a/examples/Peripherals/HardwareTimer/InputCapture/InputCapture.ino
+++ b/examples/Peripherals/HardwareTimer/InputCapture/InputCapture.ino
@@ -11,6 +11,7 @@
 uint32_t channel;
 volatile uint32_t FrequencyMeasured, LastCapture = 0, CurrentCapture;
 uint32_t input_freq = 0;
+volatile uint32_t rolloverCompareCount = 0;
 HardwareTimer *MyTim;
 
 void InputCapture_IT_callback(HardwareTimer*)
@@ -25,13 +26,20 @@ void InputCapture_IT_callback(HardwareTimer*)
     FrequencyMeasured = input_freq / (0x10000 + CurrentCapture - LastCapture);
   }
   LastCapture = CurrentCapture;
+  rolloverCompareCount = 0;
 }
 
 /* In case of timer rollover, frequency is to low to be measured set value to 0
    To reduce minimum frequency, it is possible to increase prescaler. But this is at a cost of precision. */
 void Rollover_IT_callback(HardwareTimer*)
 {
-  FrequencyMeasured = 0;
+  rolloverCompareCount++;
+
+  if (rolloverCompareCount > 1)
+  {
+    FrequencyMeasured = 0;
+  }
+
 }
 
 void setup()


### PR DESCRIPTION
Fix issue introduced by 'Fix frequency computation when there is no more signal'

It happens that frequency was measured at 0 whereas signal was present.
It is due to the fact that rollover is not abnormal:
timer is never reset to avoid missing some cpu cycles in the computation.
Loss of signal is detected by 2 consecutive rollover without rising edge.