### PR TITLE
HardwareTimer: no need to use setMode() when only update interrupt needed

### DIFF
--- a/examples/NonReg/HardwareTimer/HardwareTimer_OutputInput_test/HardwareTimer_OutputInput_test.ino
+++ b/examples/NonReg/HardwareTimer/HardwareTimer_OutputInput_test/HardwareTimer_OutputInput_test.ino
@@ -375,7 +375,6 @@ void loop()
   /*********   Output test  ***/
   test_step++;
 
-  MyTim_output->setMode(Output1_channel, TIMER_OUTPUT_COMPARE, NC);
   MyTim_output->setOverflow((1000000 / OUTPUT_FREQUENCY), MICROSEC_FORMAT);
   MyTim_output->attachInterrupt(output_Update_IT_callback);
   MyTim_output->resume();

--- a/examples/Peripherals/HardwareTimer/Timebase_callback/Timebase_callback.ino
+++ b/examples/Peripherals/HardwareTimer/Timebase_callback/Timebase_callback.ino
@@ -31,7 +31,6 @@ void setup()
   // configure pin in output mode
   pinMode(pin, OUTPUT);
 
-  MyTim->setMode(2, TIMER_OUTPUT_COMPARE);  // In our case, channekFalling is configured but not really used. Nevertheless it would be possible to attach a callback to channel compare match.
   MyTim->setOverflow(10, HERTZ_FORMAT); // 10 Hz
   MyTim->attachInterrupt(Update_IT_callback);
   MyTim->resume();


### PR DESCRIPTION
HardwareTimer: no need to use setMode() when only update interrupt needed

Require: Start timer when only update interrupt needed
https://github.com/stm32duino/Arduino_Core_STM32/pull/849

Simplify usage timebase interrupt usage: see #841