### PR TITLE
Added functionality to pass custom parameter to HardwareTimer callback

### DIFF
--- a/examples/NonReg/HardwareTimer/HardwareTimer_OutputInput_test/HardwareTimer_OutputInput_test.ino
+++ b/examples/NonReg/HardwareTimer/HardwareTimer_OutputInput_test/HardwareTimer_OutputInput_test.ino
@@ -102,23 +102,23 @@ uint32_t test_Status = PASSED;
 ** Interrupt callback
 ***************************************/
 /********    Output    *****/
-void output_Update_IT_callback(HardwareTimer *)
+void output_Update_IT_callback(void)
 {
   Output_Update++;
 }
 
-void Output_Compare1_IT_callback(HardwareTimer *)
+void Output_Compare1_IT_callback(void)
 {
   Output_Compare1++;
 }
 
-void Output_Compare2_IT_callback(HardwareTimer *)
+void Output_Compare2_IT_callback(void)
 {
   Output_Compare2++;
 }
 
 /********    Input 1   *****/
-void Input_Capture1_Rising_IT_callback(HardwareTimer *)
+void Input_Capture1_Rising_IT_callback(void)
 {
   Current1_Capture = MyTim_input->getCaptureCompare(Freq1_channelRising);
   /* frequency computation */
@@ -138,7 +138,7 @@ void Input_Capture1_Rising_IT_callback(HardwareTimer *)
   rolloverCompare1Count = 0;
 }
 
-void Input_Capture1_Falling_IT_callback(HardwareTimer *)
+void Input_Capture1_Falling_IT_callback(void)
 {
   /* prepare DutyCycle computation */
   Current1_Capture = MyTim_input->getCaptureCompare(Freq1_channelFalling);
@@ -155,7 +155,7 @@ void Input_Capture1_Falling_IT_callback(HardwareTimer *)
 }
 
 /********    Input 2   *****/
-void Input_Capture2_Rising_IT_callback(HardwareTimer *)
+void Input_Capture2_Rising_IT_callback(void)
 {
   Current2_Capture = MyTim_input->getCaptureCompare(Freq2_channelRising);
   /* frequency computation */
@@ -175,7 +175,7 @@ void Input_Capture2_Rising_IT_callback(HardwareTimer *)
   rolloverCompare2Count = 0;
 }
 
-void Input_Capture2_Falling_IT_callback(HardwareTimer *)
+void Input_Capture2_Falling_IT_callback(void)
 {
   /* prepare DutyCycle computation */
   Current2_Capture = MyTim_input->getCaptureCompare(Freq2_channelFalling);
@@ -194,7 +194,7 @@ void Input_Capture2_Falling_IT_callback(HardwareTimer *)
 /********    Input rollover   *****/
 /* In case of timer rollover, frequency is to low to be measured set values to 0
    To reduce minimum frequency, it is possible to increase prescaler. But this is at a cost of precision. */
-void Rollover_IT_callback(HardwareTimer *)
+void Rollover_IT_callback(void)
 {
   rolloverCompare1Count++;
   rolloverCompare2Count++;

--- a/examples/NonReg/HardwareTimer/HardwareTimer_OutputInput_test/HardwareTimer_OutputInput_test.ino
+++ b/examples/NonReg/HardwareTimer/HardwareTimer_OutputInput_test/HardwareTimer_OutputInput_test.ino
@@ -32,6 +32,11 @@
 /***************************************
 ** Defines
 ***************************************/
+#if !defined(STM32_CORE_VERSION) || (STM32_CORE_VERSION  < 0x01090000)
+#error "Due to API change, this sketch is compatible with STM32_CORE_VERSION  >= 0x01090000"
+#endif
+
+
 #if !defined(ARDUINO_NUCLEO_L476RG)
 #error "Sketch is applicable to NUCLEO_L476RG"
 #endif

--- a/examples/Peripherals/HardwareTimer/Frequency_Dutycycle_measurement/Frequency_Dutycycle_measurement.ino
+++ b/examples/Peripherals/HardwareTimer/Frequency_Dutycycle_measurement/Frequency_Dutycycle_measurement.ino
@@ -13,6 +13,10 @@
   This is specially true for F1 serie (BluePill, ...)
 */
 
+#if !defined(STM32_CORE_VERSION) || (STM32_CORE_VERSION  < 0x01090000)
+#error "Due to API change, this sketch is compatible with STM32_CORE_VERSION  >= 0x01090000"
+#endif
+
 #define pin  D2
 
 uint32_t channelRising, channelFalling;

--- a/examples/Peripherals/HardwareTimer/Frequency_Dutycycle_measurement/Frequency_Dutycycle_measurement.ino
+++ b/examples/Peripherals/HardwareTimer/Frequency_Dutycycle_measurement/Frequency_Dutycycle_measurement.ino
@@ -25,7 +25,7 @@ HardwareTimer *MyTim;
     @brief  Input capture interrupt callback : Compute frequency and dutycycle of input signal
 
 */
-void TIMINPUT_Capture_Rising_IT_callback(HardwareTimer*)
+void TIMINPUT_Capture_Rising_IT_callback(void)
 {
   CurrentCapture = MyTim->getCaptureCompare(channelRising);
   /* frequency computation */
@@ -47,7 +47,7 @@ void TIMINPUT_Capture_Rising_IT_callback(HardwareTimer*)
 
 /* In case of timer rollover, frequency is to low to be measured set values to 0
    To reduce minimum frequency, it is possible to increase prescaler. But this is at a cost of precision. */
-void Rollover_IT_callback(HardwareTimer*)
+void Rollover_IT_callback(void)
 {
   rolloverCompareCount++;
 
@@ -62,7 +62,7 @@ void Rollover_IT_callback(HardwareTimer*)
     @brief  Input capture interrupt callback : Compute frequency and dutycycle of input signal
 
 */
-void TIMINPUT_Capture_Falling_IT_callback(HardwareTimer*)
+void TIMINPUT_Capture_Falling_IT_callback(void)
 {
   /* prepare DutyCycle computation */
   CurrentCapture = MyTim->getCaptureCompare(channelFalling);

--- a/examples/Peripherals/HardwareTimer/InputCapture/InputCapture.ino
+++ b/examples/Peripherals/HardwareTimer/InputCapture/InputCapture.ino
@@ -19,7 +19,7 @@ uint32_t input_freq = 0;
 volatile uint32_t rolloverCompareCount = 0;
 HardwareTimer *MyTim;
 
-void InputCapture_IT_callback(HardwareTimer*)
+void InputCapture_IT_callback(void)
 {
   CurrentCapture = MyTim->getCaptureCompare(channel);
   /* frequency computation */
@@ -36,7 +36,7 @@ void InputCapture_IT_callback(HardwareTimer*)
 
 /* In case of timer rollover, frequency is to low to be measured set value to 0
    To reduce minimum frequency, it is possible to increase prescaler. But this is at a cost of precision. */
-void Rollover_IT_callback(HardwareTimer*)
+void Rollover_IT_callback(void)
 {
   rolloverCompareCount++;
 

--- a/examples/Peripherals/HardwareTimer/InputCapture/InputCapture.ino
+++ b/examples/Peripherals/HardwareTimer/InputCapture/InputCapture.ino
@@ -11,6 +11,10 @@
   This is specially true for F1 serie (BluePill, ...)
 */
 
+#if !defined(STM32_CORE_VERSION) || (STM32_CORE_VERSION  < 0x01090000)
+#error "Due to API change, this sketch is compatible with STM32_CORE_VERSION  >= 0x01090000"
+#endif
+
 #define pin  D2
 
 uint32_t channel;

--- a/examples/Peripherals/HardwareTimer/PWM_FullConfiguration/PWM_FullConfiguration.ino
+++ b/examples/Peripherals/HardwareTimer/PWM_FullConfiguration/PWM_FullConfiguration.ino
@@ -28,12 +28,12 @@
 #define pin2  D3
 #endif
 
-void Update_IT_callback(HardwareTimer*)
+void Update_IT_callback(void)
 { // Update event correspond to Rising edge of PWM when configured in PWM1 mode
   digitalWrite(pin2, LOW); // pin2 will be complementary to pin
 }
 
-void Compare_IT_callback(HardwareTimer*)
+void Compare_IT_callback(void)
 { // Compare match event correspond to falling edge of PWM when configured in PWM1 mode
   digitalWrite(pin2, HIGH);
 }

--- a/examples/Peripherals/HardwareTimer/PWM_FullConfiguration/PWM_FullConfiguration.ino
+++ b/examples/Peripherals/HardwareTimer/PWM_FullConfiguration/PWM_FullConfiguration.ino
@@ -13,7 +13,11 @@
   This is specially true for F1 serie (BluePill, ...)
 */
 
-// 'pin' PWM will be mangaed automatically by hardware whereas 'pin2' PWM will be managed by software through interrupt callback
+#if !defined(STM32_CORE_VERSION) || (STM32_CORE_VERSION  < 0x01090000)
+#error "Due to API change, this sketch is compatible with STM32_CORE_VERSION  >= 0x01090000"
+#endif
+
+// 'pin' PWM will be managed automatically by hardware whereas 'pin2' PWM will be managed by software through interrupt callback
 #if defined(LED_BUILTIN)
 #define pin  LED_BUILTIN
 

--- a/examples/Peripherals/HardwareTimer/Timebase_callback/Timebase_callback.ino
+++ b/examples/Peripherals/HardwareTimer/Timebase_callback/Timebase_callback.ino
@@ -5,6 +5,10 @@
   Once configured, there is only CPU load for callbacks executions.
 */
 
+#if !defined(STM32_CORE_VERSION) || (STM32_CORE_VERSION  < 0x01090000)
+#error "Due to API change, this sketch is compatible with STM32_CORE_VERSION  >= 0x01090000"
+#endif
+
 #if defined(LED_BUILTIN)
 #define pin  LED_BUILTIN
 #else

--- a/examples/Peripherals/HardwareTimer/Timebase_callback_with_parameter/Timebase_callback.ino
+++ b/examples/Peripherals/HardwareTimer/Timebase_callback_with_parameter/Timebase_callback.ino
@@ -1,6 +1,6 @@
 /*
   Timebase callback
-  This example shows how to configure HardwareTimer to execute a callback at regular interval.
+  This example shows how to configure HardwareTimer to execute a callback with some parameter at regular interval.
   Callback toggles pin.
   Once configured, there is only CPU load for callbacks executions.
 */
@@ -11,14 +11,19 @@
 #define pin  D2
 #endif
 
-void Update_IT_callback(void)
-{ // Toggle pin. 10hz toogle --> 5Hz PWM
-  digitalWrite(pin, !digitalRead(pin));
-}
 
+uint32_t MyData = 1; // Parameter used for callback is arbitrarily a pointer to uint32_t, it could be of other type.
+
+// Every second, print on serial MyData. And increment it.
+void Update_IT_callback(uint32_t* data)
+{
+  Serial.println(*data);
+  *data = *data + 1;
+}
 
 void setup()
 {
+  Serial.begin(9600); 
 #if defined(TIM1)
   TIM_TypeDef *Instance = TIM1;
 #else
@@ -31,8 +36,8 @@ void setup()
   // configure pin in output mode
   pinMode(pin, OUTPUT);
 
-  MyTim->setOverflow(10, HERTZ_FORMAT); // 10 Hz
-  MyTim->attachInterrupt(Update_IT_callback);
+  MyTim->setOverflow(1, HERTZ_FORMAT); // 1 Hz
+  MyTim->attachInterrupt(std::bind(Update_IT_callback, &MyData)); // bind argument to callback: When Update_IT_callback is called MyData will be given as argument
   MyTim->resume();
 }
 

--- a/examples/Peripherals/HardwareTimer/Timebase_callback_with_parameter/Timebase_callback.ino
+++ b/examples/Peripherals/HardwareTimer/Timebase_callback_with_parameter/Timebase_callback.ino
@@ -5,6 +5,10 @@
   Once configured, there is only CPU load for callbacks executions.
 */
 
+#if !defined(STM32_CORE_VERSION) || (STM32_CORE_VERSION  < 0x01090000)
+#error "Due to API change, this sketch is compatible with STM32_CORE_VERSION  >= 0x01090000"
+#endif
+
 #if defined(LED_BUILTIN)
 #define pin  LED_BUILTIN
 #else


### PR DESCRIPTION
Update example following implementation of https://github.com/stm32duino/Arduino_Core_STM32/pull/892
And add a new example to show how to use parameter.