### PR TITLE
HardwareTimer: remove use of TIMER_OUTPUT_COMPARE

### DIFF
--- a/examples/NonReg/HardwareTimer/HardwareTimer_OutputInput_test/HardwareTimer_OutputInput_test.ino
+++ b/examples/NonReg/HardwareTimer/HardwareTimer_OutputInput_test/HardwareTimer_OutputInput_test.ino
@@ -453,7 +453,7 @@ void loop()
   test_step++;
 
   MyTim_output->pauseChannel(Output1_channel);
-  MyTim_output->setMode(Output1_channel, TIMER_OUTPUT_COMPARE);
+  MyTim_output->setMode(Output1_channel, TIMER_DISABLED);
   MyTim_output->resumeChannel(Output1_channel);
   Verify_output(1, 0, 0); // in PWM2, output is the complementary of PW1
   Verify_output(2, OUTPUT_FREQUENCY, OUTPUT_DUTY2);


### PR DESCRIPTION
HardwareTimer: remove use of TIMER_OUTPUT_COMPARE

After implementation of:
https://github.com/stm32duino/Arduino_Core_STM32/pull/1247
it is better to use TIMER_DISABLED instead of  TIMER_OUTPUT_COMPARE
Even if TIMER_OUTPUT_COMPARE has been kept for compatibility
reason and is still working.
