### PR TITLE
fix(u0): VREFINT_CAL value is not programmed during production

### DIFF
--- a/examples/Peripherals/ADC/Internal_channels/Internal_channels.ino
+++ b/examples/Peripherals/ADC/Internal_channels/Internal_channels.ino
@@ -54,6 +54,13 @@ void setup() {
 
 static int32_t readVref()
 {
+#ifdef STM32U0xx
+  /* On some devices Internal voltage reference calibration value not programmed
+     during production and return 0xFFFF. See errata sheet. */
+  if ((uint32_t)(*VREFINT_CAL_ADDR) == 0xFFFF) {
+    return 3300U;
+  }
+#endif
 #ifdef __LL_ADC_CALC_VREFANALOG_VOLTAGE
 #ifdef STM32U5xx
   return (__LL_ADC_CALC_VREFANALOG_VOLTAGE(ADC1, analogRead(AVREF), LL_ADC_RESOLUTION));


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8965172d-5172-4597-ba80-82bce5fbf79c)

As a simple workaround return Vref as 3300 mv.